### PR TITLE
[Suggestion] Disable eslint indent checks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,26 @@
 {
-    "extends": "semistandard",
-    "rules": {
-        "indent": "off"
-    }
+  "extends": "semistandard",
+  "rules": {
+    "indent": [
+      "error", 2, {
+        "CallExpression": {
+          "arguments": "first"
+        },
+        "FunctionDeclaration": {
+          "body": 1,
+          "parameters": "first"
+        },
+        "FunctionExpression": {
+          "body": 1,
+          "parameters": "first"
+        },
+        "MemberExpression": 1,
+        "ObjectExpression": "first",
+        "SwitchCase": 1,
+        "ignoredNodes": [
+          "ConditionalExpression"
+        ]
+      }
+    ]
+  }
 }

--- a/test/roles/BlacklistAdminRole.test.js
+++ b/test/roles/BlacklistAdminRole.test.js
@@ -4,15 +4,14 @@
 const { shouldBehaveLikePublicRole } = require('./behaviors/PublicRole.behavior');
 const BlacklistAdminRoleMock = artifacts.require('BlacklistAdminRoleMock');
 
-contract('BlacklistAdminRole', function ([_, blacklistAdmin,
-  otherBlacklistAdmin,
-  ...otherAccounts]) {
+contract('BlacklistAdminRole', function (
+  [_, blacklistAdmin, otherBlacklistAdmin, ...otherAccounts]) {
   beforeEach(async function () {
     this.contract = await BlacklistAdminRoleMock.new({ from: blacklistAdmin });
     await this.contract.addBlacklistAdmin(otherBlacklistAdmin,
-      { from: blacklistAdmin });
+                                          { from: blacklistAdmin });
   });
 
   shouldBehaveLikePublicRole(blacklistAdmin, otherBlacklistAdmin, otherAccounts,
-    'blacklistAdmin');
+                             'blacklistAdmin');
 });

--- a/test/roles/WhitelistAdminRole.test.js
+++ b/test/roles/WhitelistAdminRole.test.js
@@ -4,15 +4,14 @@
 const { shouldBehaveLikePublicRole } = require('./behaviors/PublicRole.behavior');
 const WhitelistAdminRoleMock = artifacts.require('WhitelistAdminRoleMock');
 
-contract('WhitelistAdminRole', function ([_, whitelistAdmin,
-  otherWhitelistAdmin,
-  ...otherAccounts]) {
+contract('WhitelistAdminRole', function (
+  [_, whitelistAdmin, otherWhitelistAdmin, ...otherAccounts]) {
   beforeEach(async function () {
     this.contract = await WhitelistAdminRoleMock.new({ from: whitelistAdmin });
     await this.contract.addWhitelistAdmin(otherWhitelistAdmin,
-      { from: whitelistAdmin });
+                                          { from: whitelistAdmin });
   });
 
   shouldBehaveLikePublicRole(whitelistAdmin, otherWhitelistAdmin, otherAccounts,
-    'whitelistAdmin');
+                             'whitelistAdmin');
 });


### PR DESCRIPTION
The default standardjs indentation style is too restrictive and hinders readability by making it impossible to use indentation to distinguish between multi-line function call statements and multi-line code blocks.